### PR TITLE
Don't try to (re) auth for non 401 error codes

### DIFF
--- a/src/py_obs/osc.py
+++ b/src/py_obs/osc.py
@@ -262,7 +262,7 @@ class Osc:
                 auth=self._auth,
             )
         except aiohttp.ClientResponseError as cre_exc:
-            if cre_exc.status != 401 and self._auth is not None:
+            if cre_exc.status != 401:
                 raise ObsException(**cre_exc.__dict__) from cre_exc
 
             if cre_exc.status == 401 and self.public:

--- a/start-mini-obs.sh
+++ b/start-mini-obs.sh
@@ -18,6 +18,6 @@ git submodule init
 git submodule update
 
 # don't build the containers for testing, we don't need them and it just takes ages
-sed -i '/docker-compose.*docker-compose\.yml.*docker-compose\.minitest\.yml.*docker-compose\.minitest-user\.yml.*build.*minitest/d' Rakefile
+sed -i '/docker compose.*docker-compose\.yml.*docker-compose\.minitest\.yml.*docker-compose\.minitest-user\.yml.*build.*minitest/d' Rakefile
 rake docker:build
-docker-compose up -d
+docker compose up -d


### PR DESCRIPTION
The loginproxy only sends a `WWW-Authenticate` header on 401 errors. But if we try to reauth on 404, we fail to do so, because we don't get the correct header. We also only reach this code path if `self._auth` is None, which is the case if we have a pre-authenticated cookie.