### PR TITLE
Don't fail with a KeyError on invalid sourceinfo responses from OBS

### DIFF
--- a/src/py_obs/project.py
+++ b/src/py_obs/project.py
@@ -615,7 +615,7 @@ async def fetch_package_info(
 
     try:
         return PackageSourceInfo.from_xml(data)
-    except ValueError:
+    except (ValueError, KeyError):
         err = (_BrokenPackageSourceInfo.from_xml(data)).error
         raise ValueError(
             f"OBS could not parse the package {prj_name}/{pkg_name}: {err}"

--- a/tests/cassettes/test_package_info/test_errors_out_on_non_existing_package.yaml
+++ b/tests/cassettes/test_package_info/test_errors_out_on_non_existing_package.yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml; charset=utf-8
+    method: GET
+    uri: /source/SUSE:SLFO:Main:Build/helm?view=info&parse=1
+  response:
+    body:
+      string: "<sourceinfo package=\"helm\">\n  <error>404 package 'helm' does not\
+        \ exist</error>\n</sourceinfo>\n"
+    headers:
+      Cache-Control:
+      - private, no-transform
+      - no-cache
+      Content-Length:
+      - '93'
+      Content-Type:
+      - text/xml
+      Date:
+      - Fri, 21 Jun 2024 15:16:31 GMT
+      Server:
+      - Apache/2.4.51 (Linux/SUSE)
+      Strict-Transport-Security:
+      - max-age=31536000
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-opensuse-apiversion:
+      - 2.11~alpha.20240621T113716.56716c0a8
+      x-opensuse-runtimes:
+      - '{"view":null,"db":4.207252994179726,"backend":0}'
+      x-permitted-cross-domain-policies:
+      - none
+      x-powered-by:
+      - Phusion Passenger(R)
+      x-request-id:
+      - dc533107-c030-4309-8abf-4d5223389cb0
+      x-runtime:
+      - '0.015811'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_package_info.py
+++ b/tests/test_package_info.py
@@ -134,3 +134,17 @@ async def test_errors_out_on_non_spec_packages(osc_from_env: OSC_FROM_ENV_T) -> 
             f"OBS could not parse the package {prj}/{pkg}: no file found for build type 'spec'"
             in str(val_err_ctx.value)
         )
+
+
+@pytest.mark.vcr(filter_headers=["authorization", "openSUSE_session"])
+@pytest.mark.asyncio
+async def test_errors_out_on_non_existing_package(osc_from_env: OSC_FROM_ENV_T) -> None:
+    prj, pkg = "SUSE:SLFO:Main:Build", "helm"
+    async for osc in osc_from_env:
+        with pytest.raises(ValueError) as val_err_ctx:
+            await fetch_package_info(osc, prj, pkg)
+
+        assert (
+            f"OBS could not parse the package {prj}/{pkg}: 404 package 'helm' does not exist"
+            in str(val_err_ctx.value)
+        )


### PR DESCRIPTION
This is another workaround for https://github.com/openSUSE/open-build-service/issues/16233