### PR TITLE
Fix request creation with description

### DIFF
--- a/src/py_obs/request.py
+++ b/src/py_obs/request.py
@@ -173,7 +173,7 @@ class Request(MetaMixin):
     creator: str | None
 
     #: Optional description of this request
-    description: str | None = None
+    description: list[str] | None = None
 
     #: Set of actions that will be performed once the request is accepted
     action: list[RequestAction] = field(default_factory=list)
@@ -373,7 +373,7 @@ async def submit_package(
     rq = Request(
         id=None,
         creator=osc.username,
-        description=description,
+        description=[description] if description else None,
         action=[
             RequestAction(
                 type=ACTION,

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -372,6 +372,7 @@ async def test_request_with_revision(home_project: HOME_PROJ_T) -> None:
             osc,
             source_prj=prj.name,
             pkg=pkg.name,
+            description="This is just a test",
             dest_prj="openSUSE:Factory",
             revision=PackageRevision.LATEST,
         )


### PR DESCRIPTION
the description should be its own element, not an attribute on the request.